### PR TITLE
Fix crash when calling setMenuHeader(View v)

### DIFF
--- a/GoogleNavigationDrawerMenuLibrary/src/main/java/org/arasthel/googlenavdrawermenu/views/GoogleNavigationDrawer.java
+++ b/GoogleNavigationDrawerMenuLibrary/src/main/java/org/arasthel/googlenavdrawermenu/views/GoogleNavigationDrawer.java
@@ -442,8 +442,16 @@ public class GoogleNavigationDrawer extends DrawerLayout {
      */
     public void setMenuHeader(View v) {
         if(mListView != null) {
+            if(mListView.getAdapter() != null) {
+                ListAdapter adapter = (ListAdapter) mListView.getAdapter();
+                removeView(mListView);
+                configureList();
+                mListView.addHeaderView(v, null, isHeaderClickable());
+                mListView.setAdapter(adapter);
+            } else {
+                mListView.addHeaderView(v, null, isHeaderClickable());
+            }
             mHeaderView = v;
-            mListView.addHeaderView(v);
         }
     }
 


### PR DESCRIPTION
Similar to the fix for #6, this fixes the crash when calling setMenuHeader(View v).
